### PR TITLE
Hotfix/add shebang

### DIFF
--- a/core/execute_load.py
+++ b/core/execute_load.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #This script will pull the API data and load the tables. Eventually, a message
 #should be added that provides updates if the run fails
 


### PR DESCRIPTION
Problem
The execute_load script doesn't have a shebang

Solution
- Add the shebang that is used for python3 scripts.