### PR TITLE
Fix the runtime issue

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.1
+python-3.7.2


### PR DESCRIPTION
Why
Heroku does not allow python 3.8.1 as a runtime.

How
- Change the runtime to 3.7.2