### PR TITLE
Fix deploy files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,4 @@ urllib3
 spotipy
 gspread
 oauth2client
-smptlib
-email
 psycopg2

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.9.1


### PR DESCRIPTION
Why
The runtime and requirements files were preventing Heroku from deploying the staging branch

How
- Update the python runtime to 3.9.1 since Heroku didn't support the other runtimes
- Remove the email and smptlib libraries from the requirements. Those are default python libraries and don't need to be downloaded/installed as dependencies