### PR TITLE
Stop using audio analysis

### DIFF
--- a/core/data_pull/tracks.py
+++ b/core/data_pull/tracks.py
@@ -9,7 +9,7 @@ logging.basicConfig(filename='execute.log', filemode='a', level='INFO')
 
 # Function to be called in other files
 def recently_played():
-  """Return the recently played tracks API data"""
+  '''Return the recently played tracks API data'''
   # Set-up authorization scope. This is needed since it accesses user data
   scope = 'user-read-recently-played'
   auth_token = oauth(scope=scope)
@@ -41,7 +41,7 @@ def recently_played():
   return results, info_json
 
 def track_ids():
-  """Gets the track IDs for the recently played tracks"""
+  '''Gets the track IDs for the recently played tracks'''
   results, _ = recently_played()
 
   #Loop through each dictionary in the items list to get the track IDs
@@ -56,7 +56,7 @@ def track_ids():
   return tracks
 
 def track_features():
-  """Return high level features on each recently played track"""
+  '''Return high level features on each recently played track'''
   tracks = track_ids()
 
   #Pull the SPI into a dictionary
@@ -87,7 +87,12 @@ def track_features():
   return features_json
   
 def track_analysis():
-  """Return granular analysis on each recently played track"""
+  '''Return granular analysis on each recently played track. IMPORTANT: This is
+  not being used in the execute_load script because the size of each load is too 
+  large and it is not performant to query. The time and storage is not worth the
+  data it provides. However, I'm keeping it here in case it becomes necessary and 
+  I have access to a more powerful platform'''
+
   tracks = track_ids()
   client_scope = client()
 
@@ -129,5 +134,3 @@ def track_analysis():
         logging.info(message)
     
   return analysis_json
-
-#print(track_analysis())

--- a/core/execute_load.py
+++ b/core/execute_load.py
@@ -12,7 +12,7 @@ import logging
 user_home = os.path.expanduser("~").replace(os.sep,'/')
 sys.path.append(user_home + r"/automatic-octopus/core/storage")
 sys.path.append(user_home + r"/automatic-octopus/core/message")
-from load_tracks import tracks_to_pg, analysis_to_pg
+from load_tracks import tracks_to_pg
 from load_responses import responses_to_pg
 from transmit import communicado
 
@@ -28,8 +28,7 @@ def load_all():
   track_success = tracks_to_pg()
   response_success = responses_to_pg(sheet_name)
   sleep(60) #Making the app sleep before it executes the analysis function
-  analysis_success = analysis_to_pg()
-  success_dict = {'tracks': track_success, 'responses': response_success, 'analysis': analysis_success}
+  success_dict = {'tracks': track_success, 'responses': response_success}
 
   for key, val in success_dict.items():
     if val: # A True value means the job succeeded.
@@ -41,3 +40,6 @@ def load_all():
       timestamp = datetime.utcnow().replace(microsecond=0)
       message = f" {timestamp} Failure message sent. There was an issue when trying to load data"
       logging.info(message)
+  
+
+load_all()


### PR DESCRIPTION
Why
The audio analysis object provides potentially useful data at a very granular
level for each track. However, it has massive storage requirements and
is extremely slow to query. The information it provides is not worth these
drawbacks especially since modelling it on the fact table would be highly complicated.

How
- Remove the analysis_to_pg call from execute_load.py
- Update comments for the track_analysis pull function on tracks.py