### PR TITLE
Rename the surveys schema

### DIFF
--- a/core/storage/load_responses.py
+++ b/core/storage/load_responses.py
@@ -19,7 +19,7 @@ def responses_to_pg(sheet_name):
 
 # Establish the necessary variables
   db = "nucleus"
-  schema = "surveys"
+  schema = "survey"
   responses_json = get_responses(sheet_name)
   responses_data = responses_json.replace("'","''") #Have to escape single quotes in a postgres friendly way
   table = "responses"


### PR DESCRIPTION
Why
Instead of surveys, it should be called survey. This will help with the
naming convention in dbt since there won't be multiple plural names in the same view title.

How
Rename the schema variable in load_responses.py