### PR TITLE
Change import for getenv

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 '''This is just a placeholder app for establishing the dynos'''
 
-from os import environ
+import os
 from flask import Flask
 
 app = Flask(__name__)
@@ -10,4 +10,4 @@ def index():
     return 'Champions of Winning, Superb!'
 
 if __name__ == "__main__":
-    app.run(environ.get('PORT'))
+    app.run(os.getenv('PORT'))

--- a/core/message/transmit.py
+++ b/core/message/transmit.py
@@ -9,7 +9,7 @@
 
 # Load Libraries
 from datetime import datetime
-from os import getenv #This will be used for sending the text message
+import os  #This will be used for sending the text message
 import smtplib #This will allow us to use the SMS gateway
 from email.mime.multipart import MIMEMultipart #Needed for sending text from an email
 from email.mime.text import MIMEText #Needed for sending the text from an email
@@ -26,15 +26,15 @@ def communicado(table_group, success=False):
       results = f"\nERROR: {timestamp} Data failed to load into the {table_group} table(s).\n"
 
   #Text recipient variables
-  phone = getenv('Phone')
-  sms_gateway = getenv('Gateway')
+  phone = os.getenv('uesr_phone')
+  sms_gateway = os.getenv('user_gateway')
   recipient_address = '+1' + phone + sms_gateway
 
   # Credentials for the entity sending the text. Currently stored as local variables
   # since this is not a public facing app yet, but will want to change this
   # before it is public.
-  sender_email = getenv('messenger')
-  sender_pass = getenv('password') # Need to remove this and replace with more secure option
+  sender_email = os.getenv('messenger')
+  sender_pass = os.getenv('messenger_password') # Need to remove this and replace with more secure option
   smtp = 'smtp.gmail.com'
   port = 587
   server = smtplib.SMTP(smtp, port)

--- a/core/storage/postgres_connections.py
+++ b/core/storage/postgres_connections.py
@@ -1,13 +1,12 @@
 '''Establish a connection to the raw postgres database'''
 
 from psycopg2 import connect
-from os import getenv
-
-database = getenv("postgres_db")
-user = getenv("postgres_user")
-password = getenv("postgres_pwd")
-host = getenv("postgres_host")
-port = getenv("postgres_port")
+import os
+database = os.getenv("postgres_db")
+user = os.getenv("postgres_user")
+password = os.getenv("postgres_pwd")
+host = os.getenv("postgres_host")
+port = os.getenv("postgres_port")
 
 def pg_conn ():
     '''Use the environment variables to establish a connection to the postgres


### PR DESCRIPTION
Why
Instead of importing getenv from os, it's better to just import os and then
specify it when calling getenv in the code.

How
- Make the update to transmit.py, postgres_connections.py, and app.py
- Update some of the variables in transmit.py to make them more consistent
and easier to understand.