### PR TITLE
Change connection parameters for postgres

### DIFF
--- a/core/storage/postgres_connections.py
+++ b/core/storage/postgres_connections.py
@@ -1,22 +1,22 @@
 '''Establish a connection to the raw postgres database'''
 
-from psycopg2 import connect
+from datetime import datetime
+import psycopg2
 import os
-database = os.getenv("postgres_db")
-user = os.getenv("postgres_user")
-password = os.getenv("postgres_pwd")
-host = os.getenv("postgres_host")
-port = os.getenv("postgres_port")
+import logging
 
 def pg_conn ():
     '''Use the environment variables to establish a connection to the postgres
-    database where the API data will load'''
-    conn = connect(
-        dbname = database,
-        user = user, 
-        password = password,
-        host = host,
-        port = port
-    )
-    
+    database where the API data will load. The URL for the Heroku postgres db is
+    automatically created in the app config vars'''
+
+    DATABASE_URL = os.getenv('DATABASE_URL')
+    conn = None
+    try:
+        conn = psycopg2.connect(DATABASE_URL, sslmode='require')
+    except (psycopg2.DatabaseError) as err:
+        timestamp = datetime.utcnow().replace(microsecond=0)
+        error = f"{timestamp} ERROR: There was an issue connecting to postgres. Message: {err}"
+        logging.exception(error)
+
     return conn


### PR DESCRIPTION
Why
I'm using the postgres database in Heroku now. It provides a Database URL
in the config vars that should be used for establishing the connection.

How
- Remove the old connection vars that include db, host, password, etc.
- Add the DATABASE_URL environment variable
- Add a try/except block around the connection attempt in case something
goes wrong.