### PR TITLE
Fix Spotipy token issue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python3 app.py
+web: gunicorn app:app

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: gunicorn app:app
-worker: echo $SPOTIPY_CACHE > .cache
+worker: python3 app.py

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn app:app
+worker: echo $SPOTIPY_CACHE > .cache

--- a/app.py
+++ b/app.py
@@ -1,7 +1,14 @@
-'''Simple script to create the cache file needed for authentication'''
-import os
+'''This is just a placeholder app for establishing the dynos'''
 
-#Create or overwrite the cache file with the cache variable data
-#Eventually, this will have to be scaled for each user.
-with open('.cache', 'w') as f:
-    f.write(os.getenv('SPOTIPY_CACHE'))
+#Add this code here:
+import os
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return 'Champions of Winning, Superb!'
+
+if __name__ == "__main__":
+    app.run(os.getenv('PORT'))

--- a/app.py
+++ b/app.py
@@ -1,7 +1,13 @@
 '''This is just a placeholder app for establishing the dynos'''
 
+#Add this code here:
 import os
 from flask import Flask
+
+# Create the Spotipy cache file if it doesn't exist
+if not os.path.exists('.cache'):
+    with open('.cache', 'w') as f:
+        f.write(os.getenv('SPOTIPY_CACHE'))
 
 app = Flask(__name__)
 

--- a/app.py
+++ b/app.py
@@ -1,14 +1,7 @@
-'''This is just a placeholder app for establishing the dynos'''
-
-#Add this code here:
+'''Simple script to create the cache file needed for authentication'''
 import os
-from flask import Flask
 
-app = Flask(__name__)
-
-@app.route('/')
-def index():
-    return 'Champions of Winning, Superb!'
-
-if __name__ == "__main__":
-    app.run(os.getenv('PORT'))
+#Create or overwrite the cache file with the cache variable data
+#Eventually, this will have to be scaled for each user.
+with open('.cache', 'w') as f:
+    f.write(os.getenv('SPOTIPY_CACHE'))

--- a/app.py
+++ b/app.py
@@ -4,11 +4,6 @@
 import os
 from flask import Flask
 
-# Create the Spotipy cache file if it doesn't exist
-if not os.path.exists('.cache'):
-    with open('.cache', 'w') as f:
-        f.write(os.getenv('SPOTIPY_CACHE'))
-
 app = Flask(__name__)
 
 @app.route('/')

--- a/execute_load.py
+++ b/execute_load.py
@@ -18,16 +18,18 @@ from transmit import communicado
 # Set-up logging
 logging.basicConfig(filename='execute.log', filemode='a', level='INFO')
 
+# Create or overwrite the Spotify Oauth cache file with the cache variable data
+# Eventually, this will have to be scaled for each user.
+with open('.cache', 'w') as f:
+    f.write(os.getenv('SPOTIPY_CACHE'))
+
 def load_all():
     '''Need to have a function here so Heroku can call it. I'm currently excluding the
     response calls since it is not working correctly on raspberry pi.'''
-
     # Load the tables and send a text message if it fails
     success_dict = {'tracks': tracks_to_pg(), 'responses': responses_to_pg(os.getenv('response_sheet'))}
-
     #TODO: Add responses function call and add the results to a success dictionary
     # with the track_success data
-
     for key, val in success_dict.items():
         if val: # A True value means the job succeeded.
             #communicado(table_group=key, success=val) #This is only needed for testing.


### PR DESCRIPTION
Why
The cache file for that held the refreshable Spotify token was dropped once the dyno process completed in Heroku. This meant that I had to re-authorize it manually in Spotify.

How
- Add code to execute_load.py that creates/overwrites the .cache file with the contents of the SPOTIPY_CACHE variable. This allows the program to operate the same as before.

Note
I tried a lot of approaches, but this was the simplest for my current needs. If more users are added, something more scalable will be needed. A user class with this as a function would be effective.