### PR TITLE
Remove duplicate records

### DIFF
--- a/core/storage/load_responses.py
+++ b/core/storage/load_responses.py
@@ -43,7 +43,7 @@ def responses_to_pg(sheet_name):
                 create_table = '''create table if not exists {0}.{1}.{2} ( 
                 id serial not null primary key,
                 user_id varchar(32) not null,
-                src json not null,
+                src jsonb not null,
                 created_on_utc timestamp not null
                 );'''.format(db, schema, table)
                 cursor.execute(create_table)


### PR DESCRIPTION
Why
The API pulls from Spotify create multiple records every two hours. Cutting down on duplicates wherever possible will help with storage on the Heroku Hobby free version of Postgres.

How
- Add delete from code that runs after the load to delete any old duplicate records
- Unrelated: Convert json columns to jsonb. This is a better way to store json data when downstream json operations will be used.